### PR TITLE
Enable Shadydom use

### DIFF
--- a/sortable-list.html
+++ b/sortable-list.html
@@ -15,7 +15,7 @@
         display: inline-block;
       }
 
-      ::slotted(*) {
+      #items ::slotted(*) {
         user-drag: none;
         user-select: none;
         -moz-user-select: none;
@@ -25,7 +25,7 @@
         -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
       }
 
-      ::slotted(.item--transform) {
+      #items ::slotted(.item--transform) {
         left: 0;
         margin: 0 !important;
         position: fixed !important;
@@ -35,11 +35,11 @@
         z-index: 1;
       }
 
-      ::slotted(.item--pressed) {
+      #items ::slotted(.item--pressed) {
         transition: none !important;
       }
 
-      ::slotted(.item--dragged) {
+      #items ::slotted(.item--dragged) {
         -webkit-box-shadow: 0 2px 10px rgba(0,0,0,.2);
         box-shadow: 0 2px 10px rgba(0,0,0,.2);
         filter: brightness(1.1);


### PR DESCRIPTION
Shadydom seems to require a selector to the left of ::slotted.
https://github.com/webcomponents/shadycss#selector-scoping

Sortable-list is therefore currently not usable for apps that use Shadydom.

I added a selector left of ::slotted. This fixes the described error. 

Tested on Chrome 61.0.3163.100, Firefox 56.0.2 and Safari  11.0.1